### PR TITLE
Update callback_wrapper.hpp

### DIFF
--- a/fuse_core/include/fuse_core/callback_wrapper.hpp
+++ b/fuse_core/include/fuse_core/callback_wrapper.hpp
@@ -157,6 +157,11 @@ class CallbackAdapter : public rclcpp::Waitable
 public:
   explicit CallbackAdapter(std::shared_ptr<rclcpp::Context> context_ptr);
 
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
+
   /**
    * @brief tell the CallbackGroup how many guard conditions are ready in this waitable
    */


### PR DESCRIPTION
Fix build failure on ROS 2 Rolling by adding a required override for get_timers() in CallbackAdapter.

In ROS 2 Rolling, rclcpp::Waitable introduced a new pure virtual method get_timers() const. Since CallbackAdapter inherits from Waitable and did not implement this method, it remained abstract and could not be instantiated, causing the build to fail.

This adds a simple override that returns an empty vector, as CallbackAdapter does not use timers. This resolves the abstract class instantiation error and unblocks the Rolling sync.